### PR TITLE
support TextUtils.isEmpty()

### DIFF
--- a/android-postfix-completion.iml
+++ b/android-postfix-completion.iml
@@ -9,6 +9,7 @@
       <sourceFolder url="file://$MODULE_DIR$/src/postfixTemplates/LogTemplate" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/postfixTemplates/ToastTemplate" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/postfixTemplates/LogDTemplate" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/postfixTemplates/TextUtilsIsEmptyTemplate" isTestSource="false" />
     </content>
     <orderEntry type="jdk" jdkName="IntelliJ IDEA Community Edition IC-141.178.9" jdkType="IDEA JDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/src/com/kogitune/intellij/codeinsight/postfix/AndroidPostfixTemplateProvider.java
+++ b/src/com/kogitune/intellij/codeinsight/postfix/AndroidPostfixTemplateProvider.java
@@ -20,6 +20,7 @@ import com.intellij.codeInsight.template.postfix.templates.PostfixTemplate;
 import com.intellij.util.containers.ContainerUtil;
 import com.kogitune.intellij.codeinsight.postfix.templates.surround.LogDTemplate;
 import com.kogitune.intellij.codeinsight.postfix.templates.surround.LogTemplate;
+import com.kogitune.intellij.codeinsight.postfix.templates.surround.TextUtilsIsEmptyTemplate;
 import com.kogitune.intellij.codeinsight.postfix.templates.surround.ToastTemplate;
 import org.jetbrains.annotations.NotNull;
 
@@ -39,7 +40,8 @@ public class AndroidPostfixTemplateProvider extends JavaPostfixTemplateProvider 
         templates = ContainerUtil.<PostfixTemplate>newHashSet(
                 new ToastTemplate(),
                 new LogTemplate(),
-                new LogDTemplate()
+                new LogDTemplate(),
+                new TextUtilsIsEmptyTemplate()
         );
     }
 

--- a/src/com/kogitune/intellij/codeinsight/postfix/templates/surround/TextUtilsIsEmptyTemplate.java
+++ b/src/com/kogitune/intellij/codeinsight/postfix/templates/surround/TextUtilsIsEmptyTemplate.java
@@ -1,0 +1,51 @@
+package com.kogitune.intellij.codeinsight.postfix.templates.surround;
+
+import com.intellij.codeInsight.template.Template;
+import com.intellij.codeInsight.template.impl.ConstantNode;
+import com.intellij.codeInsight.template.impl.MacroCallNode;
+import com.intellij.openapi.util.Condition;
+import com.intellij.psi.PsiElement;
+import com.kogitune.intellij.codeinsight.postfix.internal.RichChooserStringBasedPostfixTemplate;
+import com.kogitune.intellij.codeinsight.postfix.macro.ToStringIfNeedMacro;
+import com.kogitune.intellij.codeinsight.postfix.utils.AndroidPostfixTemplatesUtils;
+import org.jetbrains.annotations.NotNull;
+
+import static com.intellij.codeInsight.template.postfix.util.JavaPostfixTemplatesUtils.IS_NON_VOID;
+import static com.kogitune.intellij.codeinsight.postfix.utils.AndroidClassName.TEXT_UTILS;
+
+/**
+ * Postfix template for android TextUtils class.
+ *
+ * @author kikuchy
+ */
+public class TextUtilsIsEmptyTemplate extends RichChooserStringBasedPostfixTemplate {
+
+    public static final Condition<PsiElement> IS_NON_NULL = new Condition<PsiElement>() {
+        @Override
+        public boolean value(PsiElement element) {
+            return IS_NON_VOID.value(element) && !AndroidPostfixTemplatesUtils.isAnnotatedNullable(element);
+        }
+
+    };
+
+    public TextUtilsIsEmptyTemplate() {
+        this("isEmpty");
+    }
+
+    public TextUtilsIsEmptyTemplate(@NotNull String alias) {
+        super(alias, "TextUtils.isEmpty(expr)", IS_NON_NULL);
+    }
+
+    @Override
+    public String getTemplateString(@NotNull PsiElement element) {
+        return getStaticMethodPrefix(TEXT_UTILS, "isEmpty", element) + "($expr$)$END$";
+    }
+
+    @Override
+    protected void addExprVariable(@NotNull PsiElement expr, Template template) {
+        final ToStringIfNeedMacro toStringIfNeedMacro = new ToStringIfNeedMacro();
+        MacroCallNode macroCallNode = new MacroCallNode(toStringIfNeedMacro);
+        macroCallNode.addParameter(new ConstantNode(expr.getText()));
+        template.addVariable("expr", macroCallNode, false);
+    }
+}

--- a/src/com/kogitune/intellij/codeinsight/postfix/templates/surround/TextUtilsIsEmptyTemplate.java
+++ b/src/com/kogitune/intellij/codeinsight/postfix/templates/surround/TextUtilsIsEmptyTemplate.java
@@ -1,12 +1,10 @@
 package com.kogitune.intellij.codeinsight.postfix.templates.surround;
 
 import com.intellij.codeInsight.template.Template;
-import com.intellij.codeInsight.template.impl.ConstantNode;
-import com.intellij.codeInsight.template.impl.MacroCallNode;
+import com.intellij.codeInsight.template.impl.TextExpression;
 import com.intellij.openapi.util.Condition;
 import com.intellij.psi.PsiElement;
 import com.kogitune.intellij.codeinsight.postfix.internal.RichChooserStringBasedPostfixTemplate;
-import com.kogitune.intellij.codeinsight.postfix.macro.ToStringIfNeedMacro;
 import com.kogitune.intellij.codeinsight.postfix.utils.AndroidPostfixTemplatesUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -29,7 +27,7 @@ public class TextUtilsIsEmptyTemplate extends RichChooserStringBasedPostfixTempl
     };
 
     public TextUtilsIsEmptyTemplate() {
-        this("isEmpty");
+        this("isemp");
     }
 
     public TextUtilsIsEmptyTemplate(@NotNull String alias) {
@@ -43,9 +41,6 @@ public class TextUtilsIsEmptyTemplate extends RichChooserStringBasedPostfixTempl
 
     @Override
     protected void addExprVariable(@NotNull PsiElement expr, Template template) {
-        final ToStringIfNeedMacro toStringIfNeedMacro = new ToStringIfNeedMacro();
-        MacroCallNode macroCallNode = new MacroCallNode(toStringIfNeedMacro);
-        macroCallNode.addParameter(new ConstantNode(expr.getText()));
-        template.addVariable("expr", macroCallNode, false);
+        template.addVariable("expr", new TextExpression(expr.getText()), false);
     }
 }

--- a/src/com/kogitune/intellij/codeinsight/postfix/utils/AndroidClassName.java
+++ b/src/com/kogitune/intellij/codeinsight/postfix/utils/AndroidClassName.java
@@ -25,7 +25,8 @@ import com.siyeh.ig.psiutils.ClassUtils;
 public enum AndroidClassName {
     TOAST("android.widget.Toast"),
     LOG("android.util.Log"),
-    CONTEXT("android.content.Context"),;
+    CONTEXT("android.content.Context"),
+    TEXT_UTILS("android.text.TextUtils"),;
 
 
     private final String fqClassName;

--- a/src/postfixTemplates/TextUtilsIsEmptyTemplate/after.java.template
+++ b/src/postfixTemplates/TextUtilsIsEmptyTemplate/after.java.template
@@ -1,0 +1,7 @@
+import com.google.common.base.Preconditions;
+
+public class Foo {
+  void m(Object o) {
+      TextUtils.isEmpty("test")
+  }
+}

--- a/src/postfixTemplates/TextUtilsIsEmptyTemplate/before.java.template
+++ b/src/postfixTemplates/TextUtilsIsEmptyTemplate/before.java.template
@@ -1,0 +1,5 @@
+public class Foo {
+  void m(Object o) {
+    <spot>o</spot>$key
+  }
+}

--- a/src/postfixTemplates/TextUtilsIsEmptyTemplate/description.html
+++ b/src/postfixTemplates/TextUtilsIsEmptyTemplate/description.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Returns true if the string is null or 0-length.
+</body>
+</html>


### PR DESCRIPTION
TextUtilsの `isEmpty()` メソッドを追加しました。

`String.isEmpty()` と一緒に表示されてしまいますが、このままでも良いでしょうか？
「既存メソッドなどと名前が重複する場合はどうする」というようなポリシーがあれば修正しますのでお教え下さい。

<img width="513" alt="2015-08-18 19 50 27" src="https://cloud.githubusercontent.com/assets/600512/9328301/9d059a9a-45e2-11e5-8331-427e8aab1b76.png">
