### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ How to run the repository code
 2. Run Gradle Wrapper
 In project root.
 ```
-./gradlew runIdea
+./gradlew runIde
 ```
 
 Thanks


### PR DESCRIPTION
I think `./gradlew runIde` is the correct command to start an IDE